### PR TITLE
Fix regression on Contacts parsing

### DIFF
--- a/vcard/parser.go
+++ b/vcard/parser.go
@@ -22,11 +22,13 @@ func ParseContacts(cardDavPayload string) ([]contact.Contact, error) {
 	for _, card := range vCards {
 		c, err := parseContact(card)
 
-		if err != nil || c.BirthDate.IsZero() {
+		if err != nil {
 			return nil, err
 		}
 
-		contacts = append(contacts, c)
+		if !c.BirthDate.IsZero() {
+			contacts = append(contacts, c)
+		}
 	}
 	return contacts, nil
 }

--- a/vcard/parser_test.go
+++ b/vcard/parser_test.go
@@ -154,10 +154,16 @@ BEGIN:VCARD
 VERSION:3.0
 FN:Alexis Foo
 END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+FN:John Bar
+BDAY:19861125
+END:VCARD
 `
 
 	contacts, err := ParseContacts(vcard)
-	assert.Equal(t, 0, len(contacts))
+	assert.Equal(t, 1, len(contacts))
+	assert.Equal(t, contact.Contact{Name: "John Bar", BirthDate: testdata.BirthDate(1986, time.November, 25)}, contacts[0])
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
When parsing contacts, we try to extract all contacts from a VCard file.

When a contact has no birthdate, we should ignore it, and iterate to other contacts

Actually, it totally skips the whole parsing and ignore every contacts located after the birthdate-less one.

This PR fixes the issue.